### PR TITLE
Adds Github actions to test container build and push to registry

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,17 +1,26 @@
-## must be run manually to push image
+## must be triggered manually to push image
 name: Build and Push Image
-on: workflow_dispatch
-  jobs:
-    push_image:
-      runs-on: ubuntu-latest
-      steps:
-      - name: Checkout Files
-        uses: actions/checkout@v2
-      - name: Build and Push Image
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: NOAA-GFDL/FRE-NCtools-container/fre-nctools-base
-          tag_with_ref: true
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version number for the pushed image"
+        required: true
+jobs:
+  push_image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Files
+      uses: actions/checkout@v2
+    - name: Login to Github Container Registry
+      uses: docker/login-action@v1
+      with: 
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+    - name: Build and Push Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: "docker.pkg.github.com/rem1776/fre-nctools-container/fre-nctools-base:${{ github.event.inputs.version }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,11 @@
 ## test successful build from file
 name: Test Dockerfile build
-on: push
-  jobs:
-    test_build:
-      runs-on: ubuntu-latest
-      steps:
-      - name: Checkout Files
-        uses: actions/checkout@v2
-      - name: Build image
-        run: docker build .
+on: [push, pull_request]
+jobs:
+  test_build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Files
+      uses: actions/checkout@v2
+    - name: Build image
+      run: docker build .


### PR DESCRIPTION
Adds two workflow yaml files:
- one to test with `docker build` on pull request and pushes
- another that builds and pushes the image to Github's container registry, through Github Packages

The registry push is set to be triggered manually, which adds a button for users with write access in the actions page for the file. It also takes the version number as input (eg. 1.0, these are used instead of tags for Github's registry), but duplicate version numbers will be overwritten. Here's the resulting package after being run on my fork: 
https://github.com/rem1776/FRE-NCtools-container/packages/667866