### PR TITLE
add spack config yaml and template to generate dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,35 +17,75 @@
 # License along with FRE-NCTools.  If not, see
 # <http://www.gnu.org/licenses/>.
 #***********************************************************************
+# Build stage with Spack pre-installed and ready to be used
+FROM spack/rockylinux9:latest as builder
 
-FROM ubuntu:focal
-LABEL maintainer="Seth Underwood <Seth.Underwood@noaa.gov>"
-LABEL copyright="2021, 2022 GFDL"
-LABEL license="LGPL v3+"
-LABEL gov.noaa.gfdl.version="3.0.0"
-LABEL vendor="Geophysical Fluid Dynamics Laboratory"
-LABEL gov.noaa.gfdl.release-date="2022-02-20"
 
-## install fre-nctools dependencies
-RUN apt-get update \
- && apt-get -y install software-properties-common \
- && add-apt-repository ppa:underwoo/nccmp --update \
- && apt-get install -y \
-    autoconf \
-    bats \
-    gfortran \
-    git \
-    libnetcdf-dev \
-    libnetcdff-dev \
-    make \
-    nccmp \
-    netcdf-bin \
-    python \
-    python3-netcdf4 \
-    python3-numpy \
-    python3-pip \
-    python3-pytest \
-    python3-venv \
-    mpich \
-    libmpich-dev \
- && pip install git+https://github.com/adcroft/numpypi.git
+# What we want to install and how we want to install it
+# is specified in a manifest file (spack.yaml)
+RUN mkdir /opt/spack-environment \
+&&  (echo spack: \
+&&   echo '  specs:' \
+&&   echo '  - gcc' \
+&&   echo '  - mpich' \
+&&   echo '  - netcdf-c' \
+&&   echo '  - netcdf-fortran' \
+&&   echo '  - nccmp' \
+&&   echo '  concretizer:' \
+&&   echo '    unify: true' \
+&&   echo '  packages:' \
+&&   echo '    all:' \
+&&   echo '      compiler: [gcc]' \
+&&   echo '  config:' \
+&&   echo '    template_dirs:' \
+&&   echo '    - /home/rem/fre-nctools-container/template' \
+&&   echo '  # container specific options' \
+&&   echo '    install_tree: /opt/software' \
+&&   echo '  view: /opt/views/view') > /opt/spack-environment/spack.yaml
+
+# Install the software, remove unnecessary deps
+RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y
+
+# Modifications to the environment that are necessary to run
+RUN cd /opt/spack-environment && \
+    spack env activate --sh -d . > activate.sh
+
+
+
+# Bare OS image to run the installed executables
+FROM docker.io/rockylinux:9
+
+COPY --from=builder /opt/spack-environment /opt/spack-environment
+COPY --from=builder /opt/software /opt/software
+
+# paths.view is a symlink, so copy the parent to avoid dereferencing and duplicating it
+COPY --from=builder /opt/views /opt/views
+
+RUN { \
+      echo '#!/bin/sh' \
+      && echo '.' /opt/spack-environment/activate.sh \
+      && echo 'exec "$@"'; \
+    } > /entrypoint.sh \
+&& chmod a+x /entrypoint.sh \
+&& ln -s /opt/views/view /opt/view
+
+
+RUN dnf update -y && dnf install -y epel-release && dnf update -y \
+ && dnf install -y autoconf libtool make bats git libgomp python3 python3-numpy python3-pip python3-pytest \
+ && rm -rf /var/cache/dnf && dnf clean all
+
+# Install any needed pip packages
+RUN pip install git+https://github.com/adcroft/numpypi.git && \
+    pip install netCDF4 virtualenv
+# Set compilers for mpich wrappers
+ENV MPICH_FC=gfortran
+ENV MPICH_CC=gcc
+LABEL "maintainer"="Seth Underwood <Seth.Underwood@noaa.gov>"
+LABEL "copyright"="2021, 2022, 2023 GFDL"
+LABEL "license"="LGPL v3+"
+LABEL "gov.noaa.gfdl.version"="5.0.0"
+LABEL "vendor"="Geophysical Fluid Dynamics Laboratory"
+LABEL "gov.noaa.gfdl.release-date"="2024-01-07"
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/bin/bash" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ LABEL "copyright"="2021, 2022, 2023 GFDL"
 LABEL "license"="LGPL v3+"
 LABEL "gov.noaa.gfdl.version"="5.0.0"
 LABEL "vendor"="Geophysical Fluid Dynamics Laboratory"
-LABEL "gov.noaa.gfdl.release-date"="2024-01-07"
+LABEL "gov.noaa.gfdl.release-date"="2024-01-10"
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # FRE-NCtools-container
 
-Recipefile and associated container used for the CI testing of the 
+Spack config and generated Dockerfile for container used for the CI testing of the
 [FRE-NCtools repository](github.com/NOAA-GFDL/FRE-NCtools). Container is based
-on Ubuntu Focal and includes all the required libraries for building and running
+on Rocky Linux 9 and includes all the required libraries for building and running
 the FRE-NCtools test suite.
+
+The Dockerfile is meant to be auto-generated with `spack containerize` via the provided
+yaml and template files. Instructions to do so are provided in `spack.yaml`.
+
+Any modifications should be made to these files, `spack.yaml` and `template/Dockerfile.template`
+instead of the resulting Dockerfile (which should then be generated and added accordingly).
 
 # Support
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,10 +19,12 @@
 #***********************************************************************
 # Ryan Mulhall 2023
 # spack environment config to generate a dockerfile for the fre-nctools ci image.
-# After any updates to generate a new dockerfile you must fill in the template_dirs below with your current
-# directory and run the following:
+# To generate a new dockerfile:
 #
-#     <clone spack and source spack/share/spack/setup-env.sh)
+#     <clone the spack repo if not already available>
+#     source spack/share/spack/setup-env.sh (setup scripts for most shells are also available)
+#     <cd to this repo>
+#     <fill in the /path/to/ in spack.yaml with the path you cloned the repo in>
 #     spack env create fnct-container-env spack.yaml
 #     spack env activate fnct-container-env
 #     spack containerize > Dockerfile
@@ -43,7 +45,7 @@ spack:
       compiler: [ gcc ]
   config:
     template_dirs:
-      - /home/rem/fre-nctools-container/template
+      - /path/to/fre-nctools-container/template
   # container specific options
   container:
     format: docker

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,80 @@
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+#
+# FRE-NCTools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FRE-NCTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+#***********************************************************************
+# Ryan Mulhall 2023
+# spack environment config to generate a dockerfile for the fre-nctools ci image.
+# After any updates to generate a new dockerfile you must fill in the template_dirs below with your current
+# directory and run the following:
+#
+#     <clone spack and source spack/share/spack/setup-env.sh)
+#     spack env create fnct-container-env spack.yaml
+#     spack env activate fnct-container-env
+#     spack containerize > Dockerfile
+#
+# For versions, spack packages will use the default (usually the newest but depends on whats compatible)
+# Images should be tagged with gcc version used
+spack:
+  specs:
+  - gcc
+  - mpich
+  - netcdf-c
+  - netcdf-fortran
+  - nccmp
+  concretizer:
+    unify: true
+  packages:
+    all:
+      compiler: [ gcc ]
+  config:
+    template_dirs:
+      - /home/rem/fre-nctools-container/template
+  # container specific options
+  container:
+    format: docker
+    template: Dockerfile.template
+    images:
+      os: "rockylinux:9"
+      spack: develop
+    # labels for final image
+    labels:
+      maintainer: "Seth Underwood <Seth.Underwood@noaa.gov>"
+      copyright: "2021, 2022, 2023 GFDL"
+      license: "LGPL v3+"
+      gov.noaa.gfdl.version: "5.0.0"
+      vendor: "Geophysical Fluid Dynamics Laboratory"
+      gov.noaa.gfdl.release-date: "2024-01-10"
+    # TODO should strip binaries for size if possible
+    # currently causes linker issues with libgcc when true
+    strip: false
+    # Additional packages that are needed at (ci) runtime
+    # this is anything that doesn't need to be built from source
+    # pip installs would be added in the template instead
+    os_packages:
+      final:
+      - autoconf
+      - libtool
+      - make
+      - bats
+      - git
+      - libgomp
+      - python3
+      - python3-numpy
+      - python3-pip
+      - python3-pytest
+

--- a/template/Dockerfile.template
+++ b/template/Dockerfile.template
@@ -1,0 +1,32 @@
+#***********************************************************************
+#                   GNU Lesser General Public License
+#
+# This file is part of the GFDL FRE NetCDF tools package (FRE-NCTools).
+#
+# FRE-NCTools is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# FRE-NCTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with FRE-NCTools.  If not, see
+# <http://www.gnu.org/licenses/>.
+#***********************************************************************
+{% extends "container/Dockerfile" %}
+{% block build_stage %}
+{{ super() }}
+{% endblock %}
+{% block final_stage %}
+{{ super() }}
+# Install any needed pip packages
+RUN pip install git+https://github.com/adcroft/numpypi.git && \
+    pip install netCDF4 virtualenv
+# Set compilers for mpich wrappers
+ENV MPICH_FC=gfortran
+ENV MPICH_CC=gcc
+{% endblock %}


### PR DESCRIPTION
Updates to use a spack generated dockerfile. The dockerfile changes were generated with spack with the added yaml and template file. I included instructions for generating it in the yaml file.

As is it will download latest compatible versions for dependencies, but we can install any versions (or build options) available in spack via the config yaml.